### PR TITLE
Use a "badge" display style for the base width in instruction listings

### DIFF
--- a/src/extensions/extension.njk
+++ b/src/extensions/extension.njk
@@ -19,7 +19,7 @@ eleventyComputed:
     <a href="/instructions/{{ inst.name }}/">{{ inst.name }}</a>
     — {{ inst.longName }}
     {% if inst.base != 32 %}
-      <span class="base-width">{{ inst.base }}</span>
+      <span class="base-width" title="This instruction is only present in the {{inst.base}}-bit version of the ISA.">{{ inst.base }}</span>
     {% endif %}
   </li>
 {% endfor %}


### PR DESCRIPTION
This is just an idea for formatting the base width so it's a little easier to process visually. Here's what the old version (on the `main` branch currently) looks like:
<img width="338" height="292" alt="Screenshot 2025-10-15 at 2 09 38 PM" src="https://github.com/user-attachments/assets/a7abb907-7d88-421e-a423-09a2859e5432" />

And here's what it looks like in this branch:
<img width="600" height="383" alt="Screenshot 2025-10-15 at 2 09 23 PM" src="https://github.com/user-attachments/assets/f8b1b318-50b0-446b-afe1-05c29fbd8fe8" />

I also added that little toolip with a longer explanation for what the badge means.