### PR TITLE
Nicer Url Structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1904,9 +1904,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-            "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {

--- a/src/lib/loadExtensions.ts
+++ b/src/lib/loadExtensions.ts
@@ -10,6 +10,10 @@ export default (): ExtensionInfo[] => {
     for (const inst of instructions) {
         const name = inst.extension || "unknown";
         const slug = inst.extensionSlug || "unknown";
+        if (slug === "unknown") {
+            console.warn(`Instruction ${inst.name} has no extension slug, using "unknown"`);
+        }
+
         if (!byExtension.has(name)) {
             byExtension.set(name, {
                 name, slug,

--- a/src/lib/loadInstructions.ts
+++ b/src/lib/loadInstructions.ts
@@ -163,8 +163,8 @@ function normalizeDefinedBy(value: unknown, fallback: string): string {
 // Convert an extension name into a URL-friendly slug
 function slugifyExtension(ext: string): string {
     return (
-        ext.toString().trim().toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
+        ext.toString().trim()
+            .replace(/[^A-Za-z0-9]+/g, "-")
             .replace(/^-+|-+$/g, "") || "unknown"
     );
 }

--- a/src/pages/extension.njk
+++ b/src/pages/extension.njk
@@ -3,7 +3,7 @@ pagination:
     data: extensions
     size: 1
     alias: extension
-permalink: extensions/{{ extension.slug }}/index.html
+permalink: "{{ extension.slug }}/index.html"
 eleventyComputed:
     title: "{{ extension.name }} Extension"
 layout: layout.njk
@@ -15,7 +15,7 @@ layout: layout.njk
 <ul class="instruction-list">
 {% for inst in extension.instructions %}
     <li data-name="{{ inst.name | lower }}">
-        <a href="/instructions/{{ inst.name }}/">{{ inst.name }}</a>
+        <a href="/{{ inst.extensionSlug }}/{{ inst.name }}/">{{ inst.name }}</a>
         — {{ inst.longName }}
         {% if inst.base != 32 %}
             <span class="base-width" title="This instruction is only present in the {{inst.base}}-bit version of the ISA.">{{ inst.base }}</span>

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -16,7 +16,7 @@ The base integer <strong>I</strong> extension is the most widely implemented set
 <ul id="extensions">
 {% for ext in extensions %}
     <li data-name="{{ ext.name | lower }}">
-        <a href="/extensions/{{ ext.slug }}/">{{ ext.name }}</a>
+        <a href="/{{ ext.slug }}/">{{ ext.name }}</a>
         <p class="extension-description">
             {% if ext.description %}
                 {{ ext.description }}

--- a/src/pages/instruction.njk
+++ b/src/pages/instruction.njk
@@ -3,7 +3,7 @@ pagination:
     data: instructions
     size: 1
     alias: inst
-permalink: instructions/{{ inst.name }}/index.html
+permalink: "{{ inst.extensionSlug }}/{{ inst.name }}/index.html"
 eleventyComputed:
     title: "{{ inst.name }}"
 layout: layout.njk

--- a/src/pages/search.njk
+++ b/src/pages/search.njk
@@ -25,7 +25,7 @@ extra_css:
         data-extension="{{ inst.extension }}"
         data-extension-slug="{{ inst.extensionSlug }}"
     >
-        <a href="/instructions/{{ inst.name }}/">{{ inst.name }}</a>
+        <a href="/{{ inst.extensionSlug }}/{{ inst.name }}/">{{ inst.name }}</a>
         <span class="ext-name" data-extension-slug="{{ inst.extensionSlug }}" title="Extension">
             - {{ inst.extension }}
         </span>


### PR DESCRIPTION
- Basically changed URLs to be of the form `riscv.fyi/M/mul` for instructions and `riscv.fyi/M` for extension pages like described in issue #10. 
- Implemented by just changing the permalink and href fields of various pages/links to use the already extracted extensionSlug field that "every" instruction should have. 
  - If an instruction doesn't have this field generated it defaults to "unknown" and generates a warning (currently no warnings, but might be more in the future when we add more instruction handling). 
  - Note also slightly changed slugify function to include capital letters, so that `M` does not turn into `m`. 