### PR TITLE
Pseudo Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 _site/
 .DS_Store
 src/**/*.js
+!src/_data/*.js

--- a/src/_data/pseudoInstructions.js
+++ b/src/_data/pseudoInstructions.js
@@ -1,0 +1,3 @@
+import loadPseudoInstructions from "../lib/loadPseudoInstructions.js";
+
+export default loadPseudoInstructions;

--- a/src/_data/searchEntries.js
+++ b/src/_data/searchEntries.js
@@ -1,28 +1,3 @@
-import loadInstructions from "../lib/loadInstructions.js";
-import loadPseudoInstructions from "../lib/loadPseudoInstructions.js";
+import loadSearchEntries from "../lib/loadSearchEntries.js";
 
-export default () => {
-    const real = loadInstructions().map((inst) => ({
-        name: inst.name,
-        search: (inst.name + " " + inst.longName).toLowerCase(),
-        mnemonic: inst.name.toLowerCase(),
-        extension: inst.extension,
-        extensionSlug: inst.extensionSlug,
-        url: `/${inst.extensionSlug}/${inst.name}/`,
-        isPseudo: false,
-        realInstName: null,
-    }));
-
-    const pseudo = loadPseudoInstructions().map((p) => ({
-        name: p.mnemonic,
-        search: p.mnemonic.toLowerCase(),
-        mnemonic: p.mnemonic.toLowerCase(),
-        extension: p.extension,
-        extensionSlug: p.extensionSlug,
-        url: `/${p.extensionSlug}/${p.realInstName}/`,
-        isPseudo: true,
-        realInstName: p.realInstName,
-    }));
-
-    return [...real, ...pseudo].sort((a, b) => a.name.localeCompare(b.name));
-};
+export default loadSearchEntries;

--- a/src/_data/searchEntries.js
+++ b/src/_data/searchEntries.js
@@ -1,0 +1,28 @@
+import loadInstructions from "../lib/loadInstructions.js";
+import loadPseudoInstructions from "../lib/loadPseudoInstructions.js";
+
+export default () => {
+    const real = loadInstructions().map((inst) => ({
+        name: inst.name,
+        search: (inst.name + " " + inst.longName).toLowerCase(),
+        mnemonic: inst.name.toLowerCase(),
+        extension: inst.extension,
+        extensionSlug: inst.extensionSlug,
+        url: `/${inst.extensionSlug}/${inst.name}/`,
+        isPseudo: false,
+        realInstName: null,
+    }));
+
+    const pseudo = loadPseudoInstructions().map((p) => ({
+        name: p.mnemonic,
+        search: p.mnemonic.toLowerCase(),
+        mnemonic: p.mnemonic.toLowerCase(),
+        extension: p.extension,
+        extensionSlug: p.extensionSlug,
+        url: `/${p.extensionSlug}/${p.realInstName}/`,
+        isPseudo: true,
+        realInstName: p.realInstName,
+    }));
+
+    return [...real, ...pseudo].sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/src/lib/loadExtensions.ts
+++ b/src/lib/loadExtensions.ts
@@ -1,4 +1,6 @@
 import loadInstructions from "./loadInstructions.js";
+import loadPseudoInstructions from "./loadPseudoInstructions.js";
+
 import * as yaml from "js-yaml";
 import * as path from "path";
 import * as fs from "fs";
@@ -57,6 +59,7 @@ function loadExtensionDescriptions(): Map<string, string> {
 // or add a separate step to include them in the output list.
 export default (): ExtensionInfo[] => {
     const instructions: InstructionInfo[] = loadInstructions();
+    const pseudoInstructions: PseudoInstructionInfo[] = loadPseudoInstructions();
     const extensionDescriptions = loadExtensionDescriptions();
     const byExtension = new Map<string, ExtensionInfo>();
 
@@ -72,18 +75,42 @@ export default (): ExtensionInfo[] => {
             byExtension.set(name, {
                 name, slug,
                 description: extensionDescriptions.get(name) ?? null,
-                instructions: [],
+                instructions: [], pseudoInstructions: [], sortedEntries: [],
+                count: 0, pseudoCount: 0,
             });
         }
         byExtension.get(name)!.instructions.push(inst);
     }
 
-    // Sort instructions within each extension and count them
+    // Group pseudo-instructions by extension
+    for (const pseudo of pseudoInstructions) {
+        byExtension.get(pseudo.extension)?.pseudoInstructions.push(pseudo);
+    }
+
+    // Sort instructions and pseudo-instructions within each extension, and create sortedEntries
     const list = Array.from(byExtension.values());
     for (const entry of list) {
-        entry.instructions.sort((a: InstructionInfo, b: InstructionInfo) =>
-            a.name.localeCompare(b.name));
+        entry.instructions.sort((a, b) => a.name.localeCompare(b.name));
         entry.count = entry.instructions.length;
+        entry.pseudoInstructions.sort((a, b) => a.mnemonic.localeCompare(b.mnemonic));
+        entry.pseudoCount = entry.pseudoInstructions.length;
+
+        const realEntries: ExtensionListEntry[] = entry.instructions.map((inst) => ({
+            name: inst.name,
+            url: `/${inst.extensionSlug}/${inst.name}/`,
+            label: inst.longName,
+            isPseudo: false,
+            base: inst.base,
+        }));
+        const pseudoEntries: ExtensionListEntry[] = entry.pseudoInstructions.map((p) => ({
+            name: p.mnemonic,
+            url: `/${p.extensionSlug}/${p.realInstName}/`,
+            label: `Pseudo-Instruction (→ ${p.realInstName})`,
+            isPseudo: true,
+            base: 32, // Default to 32-bit, but not used
+        }));
+        entry.sortedEntries = [...realEntries, ...pseudoEntries]
+            .sort((a, b) => a.name.localeCompare(b.name));
     }
 
     // Sort extensions alphabetically by name

--- a/src/lib/loadInstructions.ts
+++ b/src/lib/loadInstructions.ts
@@ -147,7 +147,7 @@ function detectEncodingType(doc: YamlDoc) {
 
 /*
 Enrich pseudo-instruction entries for display:
-- Builds `resolvedSyntax` by substituting the simple `name == value` pairs from 
+- Builds `resolvedSyntax` by substituting the simple `name == value` pairs from
 the `when` condition into the real instruction syntax.
 - Complex expressions (e.g. $signed(imm) == -1, imm[4:0] == 0) are left unreplaced.
 */

--- a/src/lib/loadInstructions.ts
+++ b/src/lib/loadInstructions.ts
@@ -145,6 +145,30 @@ function detectEncodingType(doc: YamlDoc) {
 }
 
 
+/*
+Enrich pseudo-instruction entries for display:
+- Builds `resolvedSyntax` by substituting the simple `name == value` pairs from 
+the `when` condition into the real instruction syntax.
+- Complex expressions (e.g. $signed(imm) == -1, imm[4:0] == 0) are left unreplaced.
+*/
+function preprocessPseudoInstructions(
+    pseudos: { when: string; to: string }[],
+    syntax: string,
+): PseudoInstruction[] {
+    return pseudos.map(({ when, to }) => {
+        const normalizedTo = to.replace(/,(?!\s)/g, ", ");
+        let resolvedSyntax = syntax;
+
+        // Extract simple `identifier == value` pairs; skip complex left-hand sides
+        const assignments = [...when.matchAll(/\b([a-zA-Z_]\w*)\s*==\s*([^\s)&|,\]]+)/g)];
+        for (const [, name, value] of assignments) {
+            resolvedSyntax = resolvedSyntax.replace(new RegExp(`\\b${name}\\b`, "g"), value);
+        }
+        return { when: when, to: normalizedTo, resolvedSyntax };
+    });
+}
+
+
 // Normalize the "definedBy" field into a consistent string format for display.
 function normalizeDefinedBy(value: unknown, fallback: string): string {
     if (!value) return fallback;
@@ -281,6 +305,10 @@ export default function loadInstructions(): InstructionInfo[] {
                 },
                 extensionSlug: slugifyExtension(extension),
                 extension, bitfieldSVG,
+                pseudoinstructions: preprocessPseudoInstructions(
+                    doc.pseudoinstructions ?? [],
+                    (doc.name + " " + assemblyArgs).trim(),
+                ),
             });
         }
     }

--- a/src/lib/loadPseudoInstructions.ts
+++ b/src/lib/loadPseudoInstructions.ts
@@ -1,0 +1,27 @@
+import loadInstructions from "./loadInstructions.js";
+
+
+let cache: PseudoInstructionInfo[] | null = null;
+
+
+// Returns a flat list of all pseudo-instructions across all extensions.
+// Same-mnemonic shortened forms (e.g. "jal imm" from jal) are excluded since
+// they aren't independently searchable mnemonics.
+export default function loadPseudoInstructions(): PseudoInstructionInfo[] {
+    if (cache) return cache;
+    const pseudoInstructions: PseudoInstructionInfo[] = loadInstructions()
+        .flatMap((inst) =>
+            inst.pseudoinstructions
+                .filter((p) => p.to.split(" ")[0] !== inst.name)
+                .map((p) => ({
+                    mnemonic: p.to.split(" ")[0],
+                    syntax: p.to,
+                    realInstName: inst.name,
+                    extension: inst.extension,
+                    extensionSlug: inst.extensionSlug,
+                }))
+        );
+
+    cache = pseudoInstructions;
+    return pseudoInstructions;
+}

--- a/src/lib/loadSearchEntries.ts
+++ b/src/lib/loadSearchEntries.ts
@@ -25,5 +25,5 @@ export default function loadSearchEntries(): SearchEntry[] {
         realInstName: p.realInstName,
     }));
 
-    return [...real, ...pseudo].sort((a, b) => a.name.localeCompare(b.name));
+    return [...real, ...pseudo].sort((a, b) => a.extension.localeCompare(b.extension) || a.name.localeCompare(b.name));
 }

--- a/src/lib/loadSearchEntries.ts
+++ b/src/lib/loadSearchEntries.ts
@@ -1,0 +1,29 @@
+import loadInstructions from "./loadInstructions.js";
+import loadPseudoInstructions from "./loadPseudoInstructions.js";
+
+
+export default function loadSearchEntries(): SearchEntry[] {
+    const real: SearchEntry[] = loadInstructions().map((inst) => ({
+        name: inst.name,
+        search: (inst.name + " " + inst.longName).toLowerCase(),
+        mnemonic: inst.name.toLowerCase(),
+        extension: inst.extension,
+        extensionSlug: inst.extensionSlug,
+        url: `/${inst.extensionSlug}/${inst.name}/`,
+        isPseudo: false,
+        realInstName: null,
+    }));
+
+    const pseudo: SearchEntry[] = loadPseudoInstructions().map((p) => ({
+        name: p.mnemonic,
+        search: p.mnemonic.toLowerCase(),
+        mnemonic: p.mnemonic.toLowerCase(),
+        extension: p.extension,
+        extensionSlug: p.extensionSlug,
+        url: `/${p.extensionSlug}/${p.realInstName}/`,
+        isPseudo: true,
+        realInstName: p.realInstName,
+    }));
+
+    return [...real, ...pseudo].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -20,6 +20,13 @@ interface EncodingDoc {
 }
 
 
+interface PseudoInstruction {
+    when: string;
+    to: string;
+    resolvedSyntax: string;
+}
+
+
 interface YamlDoc {
     name: string;
     long_name?: string;
@@ -28,6 +35,7 @@ interface YamlDoc {
     base?: number;
     assembly?: string | string[];
     encoding?: EncodingDoc;
+    pseudoinstructions?: PseudoInstruction[];
 }
 
 interface InstructionInfo {
@@ -50,6 +58,7 @@ interface InstructionInfo {
     extension: string;
     extensionSlug: string;
     bitfieldSVG: string;
+    pseudoinstructions: PseudoInstruction[];
 }
 
 interface ExtensionInfo {

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -93,6 +93,18 @@ interface ExtensionInfo {
 }
 
 
+interface SearchEntry {
+    name: string;
+    search: string;
+    mnemonic: string;
+    extension: string;
+    extensionSlug: string;
+    url: string;
+    isPseudo: boolean;
+    realInstName: string | null;
+}
+
+
 declare module "bit-field/lib/render.js" {
     interface BitFieldSegment {
         name: string;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -3,6 +3,7 @@ interface Segment {
     to: number;
 }
 
+
 interface Field {
     label: string;
     from: number;
@@ -38,6 +39,7 @@ interface YamlDoc {
     pseudoinstructions?: PseudoInstruction[];
 }
 
+
 interface InstructionInfo {
     name: string;
     longName: string;
@@ -61,12 +63,33 @@ interface InstructionInfo {
     pseudoinstructions: PseudoInstruction[];
 }
 
+
+interface PseudoInstructionInfo {
+    mnemonic: string;
+    syntax: string;
+    realInstName: string;
+    extension: string;
+    extensionSlug: string;
+}
+
+
+interface ExtensionListEntry {
+    name: string;
+    url: string;
+    label: string;
+    isPseudo: boolean;
+    base: number;
+}
+
 interface ExtensionInfo {
     name: string;
     slug: string;
     description: string | null;
     instructions: InstructionInfo[];
-    count?: number;
+    pseudoInstructions: PseudoInstructionInfo[];
+    sortedEntries: ExtensionListEntry[];
+    count: number;
+    pseudoCount: number;
 }
 
 

--- a/src/pages/extension.njk
+++ b/src/pages/extension.njk
@@ -10,15 +10,19 @@ layout: layout.njk
 ---
 <h1>{{ extension.name }} Extension</h1>
 
-<p>{{ extension.count }} instructions in the {{ extension.name }} extension.</p>
+<p>{{ extension.count }} instructions and {{ extension.pseudoCount }} pseudo-instructions in the {{ extension.name }} extension.</p>
 
 <ul class="instruction-list">
-{% for inst in extension.instructions %}
-    <li data-name="{{ inst.name | lower }}">
-        <a href="/{{ inst.extensionSlug }}/{{ inst.name }}/">{{ inst.name }}</a>
-        — {{ inst.longName }}
-        {% if inst.base != 32 %}
-            <span class="base-width" title="This instruction is only present in the {{inst.base}}-bit version of the ISA.">{{ inst.base }}</span>
+{% for entry in extension.sortedEntries %}
+    <li data-name="{{ entry.name | lower }}">
+        <a href="{{ entry.url }}">{{ entry.name }}</a>
+        {% if entry.isPseudo %}
+            - <span class="extension-description">{{ entry.label }}</span>
+        {% else %}
+            - {{ entry.label}}
+            {% if entry.base != 32 %}
+                <span class="base-width" title="This instruction is only present in the {{entry.base}}-bit version of the ISA.">{{ entry.base }}</span>
+            {% endif %}
         {% endif %}
     </li>
 {% endfor %}

--- a/src/pages/instruction.njk
+++ b/src/pages/instruction.njk
@@ -17,6 +17,16 @@ extra_css:
 <section>
     <h2>Synopsis</h2>
     <pre><code>{{ inst.syntax }}</code></pre>
+
+    <ul>
+        {% for pseudo in inst.pseudoinstructions %}
+            <li>
+                <pre><b>Pseudo-Instruction</b> <code>{{ pseudo.to }}</code>
+            <b>equals</b> <code>{{ pseudo.resolvedSyntax }}</code>
+              <b>when</b> <code>{{ pseudo.when }}</code></pre>
+            </li>
+        {% endfor %}
+    </ul>
 </section>
 
 <section>
@@ -34,6 +44,7 @@ extra_css:
         {% if inst.encoding.opcode %}<div><strong>opcode</strong>: {{ inst.encoding.opcode }}</div>{% endif %}
     </div>
 </section>
+
 
 <section>
     <h2>RISC-V Instruction Encoder/Decoder</h2>

--- a/src/pages/search.njk
+++ b/src/pages/search.njk
@@ -31,6 +31,21 @@ extra_css:
         </span>
     </li>
 {% endfor %}
+
+{% for pseudo in pseudoInstructions %}
+    <li
+        data-search="{{ pseudo.mnemonic | lower }}"
+        data-mnemonic="{{ pseudo.mnemonic | lower }}"
+        data-extension="{{ pseudo.extension }}"
+        data-extension-slug="{{ pseudo.extensionSlug }}"
+    >
+        <a href="/{{ pseudo.extensionSlug }}/{{ pseudo.realInstName }}/">{{ pseudo.mnemonic }}</a>
+        <span class="ext-name" title="Extension">
+            - {{ pseudo.extension }}
+        </span>
+        <span class="extension-description">Pseudo-Instruction (&#8594; {{ pseudo.realInstName }})</span>
+    </li>
+{% endfor %}
 </ul>
 
 <script type="module" src="/scripts/search.js"></script>

--- a/src/pages/search.njk
+++ b/src/pages/search.njk
@@ -18,32 +18,18 @@ extra_css:
 </fieldset>
 
 <ul id="instruction_list">
-{% for inst in instructions %}
+{% for entry in searchEntries %}
     <li
-        data-search="{{ (inst.name ~ ' ' ~ inst.longName) | lower }}"
-        data-mnemonic="{{ inst.name | lower }}"
-        data-extension="{{ inst.extension }}"
-        data-extension-slug="{{ inst.extensionSlug }}"
+        data-search="{{ entry.search }}"
+        data-mnemonic="{{ entry.mnemonic }}"
+        data-extension="{{ entry.extension }}"
+        data-extension-slug="{{ entry.extensionSlug }}"
     >
-        <a href="/{{ inst.extensionSlug }}/{{ inst.name }}/">{{ inst.name }}</a>
-        <span class="ext-name" title="Extension">
-            - {{ inst.extension }}
-        </span>
-    </li>
-{% endfor %}
-
-{% for pseudo in pseudoInstructions %}
-    <li
-        data-search="{{ pseudo.mnemonic | lower }}"
-        data-mnemonic="{{ pseudo.mnemonic | lower }}"
-        data-extension="{{ pseudo.extension }}"
-        data-extension-slug="{{ pseudo.extensionSlug }}"
-    >
-        <a href="/{{ pseudo.extensionSlug }}/{{ pseudo.realInstName }}/">{{ pseudo.mnemonic }}</a>
-        <span class="ext-name" title="Extension">
-            - {{ pseudo.extension }}
-        </span>
-        <span class="extension-description">Pseudo-Instruction (&#8594; {{ pseudo.realInstName }})</span>
+        <a href="{{ entry.url }}">{{ entry.name }}</a>
+        <span class="ext-name" title="Extension">- {{ entry.extension }}</span>
+        {% if entry.isPseudo %}
+            <span class="extension-description">Pseudo-Instruction (→ {{ entry.realInstName }})</span>
+        {% endif %}
     </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
- Parsed single replacement pseudo instructions like `nop = addi x0, x0, 0` and display them in the original instruction pages under the synopsis section. 
- These single replacement pseudo instructions are not given their own page, because the `riscv-unified-db` does not have any further explanation/details beyond replacement rules. 
- Despite not having their own pages, the single replacement pseudo instructions are added to the `extensions` pages and the search pages in which they are linked to the original instruction pages. 
- Finally multiple replacement pseudo instructions like `call` (desugars into `auipc` and `jalr`) are not mentioned in the `riscv-unified-db` to the best of my knowledge, so I have not included them in this PR, we might have to take a look at other sources or hardcode them ourselves. 